### PR TITLE
[Feat] 축준위&프로모션 부스 상세페이지 스크랩 관련 로직 추가

### DIFF
--- a/src/pages/DetailPage/shared/components/BoothButton.jsx
+++ b/src/pages/DetailPage/shared/components/BoothButton.jsx
@@ -45,13 +45,17 @@ const BoothButton = ({
                   : '부스 운영진 연락처'}
             </ContactText>
           </ButtonItem>
-          <ColumnDivider />
-          <ButtonItem>
-            <ScrapButton as='div'>
-              <ScrapIcon onClick={handleScrap} $isScraped={isScrap} />
-            </ScrapButton>
-            <ContactText>{localScrapCount}명이 스크랩했어요</ContactText>
-          </ButtonItem>
+          {!isCommittee && (
+            <>
+              <ColumnDivider />
+              <ButtonItem>
+                <ScrapButton as='div'>
+                  <ScrapIcon onClick={handleScrap} $isScraped={isScrap} />
+                </ScrapButton>
+                <ContactText>{localScrapCount}명이 스크랩했어요</ContactText>
+              </ButtonItem>
+            </>
+          )}
         </ButtonContainer>
       </ButtonWrapper>
 


### PR DESCRIPTION
## 📌 관련 이슈
#79 
<br/> 

## 📝 요약(Summary)
축준위 & 프로모션 부스 상세페이지 접속 시 스크랩 버튼 없이 중앙에 축준위 연락처만 보이게 수정
<br/> 


## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
