### PR TITLE
[Fix] 부스 상세 썸네일 이미지 위치 조정 (object-position)

### DIFF
--- a/src/pages/DetailPage/shared/components/DetailTemplate.jsx
+++ b/src/pages/DetailPage/shared/components/DetailTemplate.jsx
@@ -16,6 +16,7 @@ const BoothThumbnail = styled.img`
   width: 100%;
   height: 15rem;
   object-fit: cover;
+  object-position: center 40%;
   background: linear-gradient(
     180deg,
     rgba(0, 0, 0, 0.8) 35.78%,


### PR DESCRIPTION
## 📌 관련 이슈
#79 
<br/> 

## 📝 요약(Summary)
부스 상세 썸네일 이미지 높이 기준점 40%로 조정
<br/> 


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
